### PR TITLE
Update version to 0.57.0

### DIFF
--- a/recipe/fix_readable_log_record_import.patch
+++ b/recipe/fix_readable_log_record_import.patch
@@ -1,0 +1,18 @@
+--- a/packages/opentelemetry-instrumentation-transformers/tests/test_pipeline.py
++++ b/packages/opentelemetry-instrumentation-transformers/tests/test_pipeline.py
+@@ -1,6 +1,5 @@
+ import pytest
+ import importlib.util
+-from opentelemetry.sdk._logs import ReadableLogRecord
+ from opentelemetry.semconv._incubating.attributes import (
+     gen_ai_attributes as GenAIAttributes,
+ )
+@@ -92,7 +91,7 @@
+     assert_message_in_logs(logs[1], "gen_ai.choice", choice_event)
+ 
+ 
+-def assert_message_in_logs(log: ReadableLogRecord, event_name: str, expected_content: dict):
++def assert_message_in_logs(log, event_name: str, expected_content: dict):
+     assert log.log_record.event_name == event_name
+     assert (
+         log.log_record.attributes.get(GenAIAttributes.GEN_AI_SYSTEM) == "transformers"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-transformers" %}
-{% set version = "0.49.6" %}
+{% set version = "0.57.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,26 +7,28 @@ package:
 
 source:
   url: https://github.com/traceloop/openllmetry/archive/refs/tags/{{ version }}.tar.gz
-  sha256: dd728fb9146daa770dc5e5b0786f5ae894aca1b274f13799114aa71030fbdff3
+  sha256: 1d50744523e5bd100fa729f39cbbafbae49b2416e9644327bc716bf9eebccfc1
+  patches:
+    - fix_readable_log_record_import.patch
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install ./packages/{{ name }} -vv --no-deps --no-build-isolation
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 requirements:
   host:
     - pip
     - python
-    - poetry-core
+    - hatchling
   run:
     - python
     - opentelemetry-api >=1.38.0,<2.0.0
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
-    - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5.0
+    - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
   run_constrained:
-    - transformers >=4.51.3, <5.0.0
+    - transformers
 
 test:
   source_files:
@@ -39,7 +41,9 @@ test:
   requires:
     - pip
     - pytest >=8.2.2,<9
-    - transformers >=4.51.3,<5.0.0
+    - pytorch
+    - transformers >=4.51.3,<5.0.0 # [py<314]
+    - transformers >=5.0.0 # [py>=314]
     - opentelemetry-sdk >=1.34.1,<2
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,6 @@ test:
   requires:
     - pip
     - pytest >=8.2.2,<9
-    - pytorch
     - transformers >=4.51.3,<5.0.0 # [py<314]
     - transformers >=5.0.0 # [py>=314]
     - opentelemetry-sdk >=1.34.1,<2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,6 @@ requirements:
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
-  run_constrained:
-    - transformers
 
 test:
   source_files:


### PR DESCRIPTION
opentelemetry-instrumentation-transformers 0.57.0

**Destination channel:** defaults

### Links

- [PKG-13422](https://anaconda.atlassian.net/browse/PKG-13422) 
- [Upstream repository](https://github.com/traceloop/openllmetry/tree/v0.57.0/packages/opentelemetry-instrumentation-transformers/opentelemetry/instrumentation/transformers)

### Explanation of changes:
- New version number


[PKG-13422]: https://anaconda.atlassian.net/browse/PKG-13422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ